### PR TITLE
🐛 bug-fix: carousel speed incresing

### DIFF
--- a/src/components/home-page/icons-carousel-infinite-scroll/icons-carousel.tsx
+++ b/src/components/home-page/icons-carousel-infinite-scroll/icons-carousel.tsx
@@ -24,7 +24,7 @@ export default function IconsCarousel({
     });
     scrollerRef.current?.parentNode instanceof HTMLDivElement &&
       scrollerRef.current.parentNode.setAttribute("data-animate", "true");
-  });
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
Issue: closes #8

It was happening because of the absence of dependency array of `useEffect` hook.